### PR TITLE
upload compiler for Raspberry Pi

### DIFF
--- a/compiler/jalv24q5_rpi.txt
+++ b/compiler/jalv24q5_rpi.txt
@@ -1,0 +1,1 @@
+This folder contains the binary of the compiler for JAL version 2.4q5 for use on Raspberry Pi and similar ARM-based single-board computers.


### PR DESCRIPTION
Uploaded binary of JAL V2.4q5 compiler for Raspberry Pi and similar single-board computers.